### PR TITLE
Fix script for running inside a private network.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -20,7 +20,7 @@ NESTED = true
 PREFIX = NAME_PREFIX + CLUSTER
 
 # needed for kubeadm to add to cert
-HOSTIP = Socket.ip_address_list.reject( &:ipv4_loopback? ).reject( &:ipv6_loopback? ).reject( &:ipv4_private? ).reject( &:ipv6? )[0].ip_address
+HOSTIP = Socket.ip_address_list.reject( &:ipv4_loopback? ).reject( &:ipv6_loopback? ).reject( &:ipv6? ).map{|ip| ip.ip_address}.join(",")
 
 Vagrant.configure("2") do |config|
     config.ssh.insert_key = false


### PR DESCRIPTION
Let's use all local non-loopback IP4 addresses for the certs.

This way, the script can run in a private network (e.g., home wifi behind a NAT).
As a side effect, this allows to proxy the API port to other VMs and containers running locally in a separate private network.

An alternative would be to use something like following to get the "main" IP routing towards internet no matter if in private range or not:
```
HOSTIP = UDPSocket.open {|s| s.connect("64.233.187.99", 1); s.addr.last}
```