### PR TITLE
pin down the version of python cryptography module

### DIFF
--- a/roles/nodes/tasks/tls.yml
+++ b/roles/nodes/tasks/tls.yml
@@ -11,7 +11,7 @@
 - name: install python packages
   pip:
     name:
-      - cryptography
+      - cryptography==3.3.2
 
 - name: Create /etc/pwx
   file: path=/etc/pwx state=directory


### PR DESCRIPTION
This fixes "No module named 'setuptools_rust'" error.
Reference: https://github.com/Azure/azure-cli/issues/16858