### PR TITLE
tweak subject alternate names in the server cert

### DIFF
--- a/roles/nodes/tasks/tls.yml
+++ b/roles/nodes/tasks/tls.yml
@@ -34,7 +34,7 @@
   openssl_csr:
     path: /etc/pwx/server.csr
     privatekey_path: /etc/pwx/server.key
-    subject_alt_name: "DNS:localhost,DNS:{{ inventory_hostname }},DNS:{{ ansible_eth0.ipv4.address }},DNS:{{ ansible_eth1.ipv4.address }}"
+    subject_alt_name: "DNS:portworx-service.kube-system,DNS:localhost,DNS:{{ inventory_hostname }},IP:{{ ansible_eth0.ipv4.address }},IP:{{ ansible_eth1.ipv4.address }},IP:{{ kubeup_host_ip }}"
 
 - name: create certs
   openssl_certificate:


### PR DESCRIPTION
- use IP: instead of DNS: for ip addrs
- add host IP so that we can run pxc on the external machine with socat
  to node:9020 running on the host
- add portworx service name since that is what is used by autopilot